### PR TITLE
Fixed issues with dark themes and radio/check buttons

### DIFF
--- a/hops/application_windows.py
+++ b/hops/application_windows.py
@@ -10,11 +10,11 @@ import webbrowser
 import warnings
 
 from tkinter import Tk, TclError
-from tkinter import Label, Button, Entry, Checkbutton, Scrollbar, Listbox, PhotoImage, Radiobutton, Scale, Frame, Canvas
+from tkinter import Label, Button, Entry, Scrollbar, Listbox, PhotoImage, Scale, Frame, Canvas
 from tkinter import StringVar, BooleanVar, DoubleVar, IntVar
 from tkinter import DISABLED, NORMAL, END, RIGHT, LEFT, TOP, BOTTOM, BOTH, Y, HORIZONTAL, VERTICAL, E, W, N, S, NW, TRUE, FALSE
 
-from tkinter.ttk import Combobox, Style, Progressbar
+from tkinter.ttk import Combobox, Style, Progressbar, Radiobutton, Checkbutton
 from tkinter.filedialog import askdirectory
 from tkinter.messagebox import showinfo, askyesno, askyesnocancel
 
@@ -322,7 +322,7 @@ class HOPSWindow:
                         obj[0].config(borderwidth=buttons_bd, font=button_font, padx=1, pady=1)
                     elif obj[0].winfo_class() == 'Entry':
                         obj[0].configure(width=entries_wd, bd=entries_bd, font=main_font)
-                    elif obj[0].winfo_class() in ['Label', 'Radiobutton', 'Checkbutton']:
+                    elif obj[0].winfo_class() in ['Label']:
                         if len(obj) == 5:
                             if obj[4] == 'title':
                                 obj[0].configure(font=title_font, padx=0, pady=0)


### PR DESCRIPTION
Using Debian 11 with KDE and a dark theme the check/radio buttons don't show what is selected, this switches them to use the ttk themed ones which seemed the simplest solution see attached before and after:

Before:
![before](https://github.com/ExoWorldsSpies/hops/assets/151715/6aa12f69-7c84-4368-b6e0-772adfcd13e7)

After:
![after](https://github.com/ExoWorldsSpies/hops/assets/151715/b6192ecb-2eac-4a8b-9507-ec7e52d7e8a2)
